### PR TITLE
Allow configurated CSS selectors and class names 

### DIFF
--- a/bs-stepper.d.ts
+++ b/bs-stepper.d.ts
@@ -1,6 +1,18 @@
 declare type StepperOptions = {
   linear: boolean,
-  animation: boolean
+  animation: boolean,
+  selectors: {
+    steps: string,
+    trigger: string,
+    stepper: string
+  },
+  classNames: {
+    active: string,
+    linear: string,
+    block: string,
+    none: string,
+    fade: string
+  }
 };
 
 declare class Stepper {

--- a/bs-stepper.d.ts
+++ b/bs-stepper.d.ts
@@ -5,13 +5,6 @@ declare type StepperOptions = {
     steps: string,
     trigger: string,
     stepper: string
-  },
-  classNames: {
-    active: string,
-    linear: string,
-    block: string,
-    none: string,
-    fade: string
   }
 };
 

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,4 +1,4 @@
-import { show, customProperty, detectAnimation } from './util'
+import { show, customProperty, detectAnimation, ClassName } from './util'
 import { buildClickStepLinearListener, buildClickStepNonLinearListener } from './listeners'
 
 const DEFAULT_OPTIONS = {
@@ -8,13 +8,6 @@ const DEFAULT_OPTIONS = {
     steps: '.step',
     trigger: '.step-trigger',
     stepper: '.bs-stepper'
-  },
-  classNames: {
-    active: 'active',
-    linear: 'linear',
-    block: 'dstepper-block',
-    none: 'dstepper-none',
-    fade: 'fade'
   }
 }
 
@@ -35,13 +28,8 @@ class Stepper {
       ...this.options.selectors
     }
 
-    this.options.classNames = {
-      ...DEFAULT_OPTIONS.classNames,
-      ...this.options.classNames
-    }
-
     if (this.options.linear) {
-      this._element.classList.add(this.options.classNames.linear)
+      this._element.classList.add(ClassName.LINEAR)
     }
 
     this._steps = [].slice.call(this._element.querySelectorAll(this.options.selectors.steps))

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -103,13 +103,9 @@ class Stepper {
       const trigger = step.querySelector(this.options.selectors.trigger)
 
       if (this.options.linear) {
-        if (this._clickStepLinearListener) {
-          trigger.removeEventListener('click', this._clickStepLinearListener)
-        }
+        trigger.removeEventListener('click', this._clickStepLinearListener)
       } else {
-        if (this._clickStepNonLinearListener) {
-          trigger.removeEventListener('click', this._clickStepNonLinearListener)
-        }
+        trigger.removeEventListener('click', this._clickStepNonLinearListener)
       }
     })
 

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -22,7 +22,6 @@ class Stepper {
       ..._options
     }
 
-    // FIXME(ioxua-os): Find a better alternative to deep copy objects
     this.options.selectors = {
       ...DEFAULT_OPTIONS.selectors,
       ...this.options.selectors

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -29,6 +29,17 @@ class Stepper {
       ..._options
     }
 
+    // FIXME(ioxua-os): Find a better alternative to deep copy objects
+    this.options.selectors = {
+      ...DEFAULT_OPTIONS.selectors,
+      ...this.options.selectors
+    }
+
+    this.options.classNames = {
+      ...DEFAULT_OPTIONS.classNames,
+      ...this.options.classNames
+    }
+
     if (this.options.linear) {
       this._element.classList.add(this.options.classNames.linear)
     }

--- a/src/js/listeners.js
+++ b/src/js/listeners.js
@@ -1,23 +1,27 @@
 import { closest } from './polyfill'
-import { Selectors, customProperty, show } from './util'
+import { customProperty, show } from './util'
 
-function clickStepLinearListener (event) {
-  event.preventDefault()
+function buildClickStepLinearListener (options) {
+  return function clickStepLinearListener (event) {
+    event.preventDefault()
+  }
 }
 
-function clickStepNonLinearListener (event) {
-  event.preventDefault()
+function buildClickStepNonLinearListener (options) {
+  return function clickStepNonLinearListener (event) {
+    event.preventDefault()
 
-  const step = closest(event.target, Selectors.STEPS)
-  const stepperNode = closest(step, Selectors.STEPPER)
-  const stepper = stepperNode[customProperty]
-  const stepIndex = stepper._steps.indexOf(step)
+    const step = closest(event.target, options.selectors.steps)
+    const stepperNode = closest(step, options.selectors.stepper)
+    const stepper = stepperNode[customProperty]
+    const stepIndex = stepper._steps.indexOf(step)
 
-  stepper._currentIndex = stepIndex
-  show(stepperNode, stepIndex)
+    stepper._currentIndex = stepIndex
+    show(stepperNode, stepIndex, options)
+  }
 }
 
 export {
-  clickStepLinearListener,
-  clickStepNonLinearListener
+  buildClickStepLinearListener,
+  buildClickStepNonLinearListener
 }

--- a/src/js/listeners.js
+++ b/src/js/listeners.js
@@ -1,13 +1,13 @@
 import { closest } from './polyfill'
 import { customProperty, show } from './util'
 
-function buildClickStepLinearListener (options) {
+const buildClickStepLinearListener = (options) => {
   return function clickStepLinearListener (event) {
     event.preventDefault()
   }
 }
 
-function buildClickStepNonLinearListener (options) {
+const buildClickStepNonLinearListener = (options) => {
   return function clickStepNonLinearListener (event) {
     event.preventDefault()
 

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -2,13 +2,21 @@ import { WinEvent, createCustomEvent } from './polyfill'
 
 const MILLISECONDS_MULTIPLIER = 1000
 
+const ClassName = {
+  ACTIVE: 'active',
+  LINEAR: 'linear',
+  BLOCK: 'dstepper-block',
+  NONE: 'dstepper-none',
+  FADE: 'fade'
+}
+
 const transitionEndEvent = 'transitionend'
 const customProperty = 'bsStepper'
 
 const show = (stepperNode, indexStep, options) => {
   const stepper = stepperNode[customProperty]
 
-  if (stepper._steps[indexStep].classList.contains(options.classNames.active) || stepper._stepsContents[indexStep].classList.contains(options.classNames.active)) {
+  if (stepper._steps[indexStep].classList.contains(ClassName.ACTIVE) || stepper._stepsContents[indexStep].classList.contains(ClassName.ACTIVE)) {
     return
   }
 
@@ -20,19 +28,19 @@ const show = (stepperNode, indexStep, options) => {
   })
   stepperNode.dispatchEvent(showEvent)
 
-  const activeStep = stepper._steps.filter(step => step.classList.contains(options.classNames.active))
-  const activeContent = stepper._stepsContents.filter(content => content.classList.contains(options.classNames.active))
+  const activeStep = stepper._steps.filter(step => step.classList.contains(ClassName.ACTIVE))
+  const activeContent = stepper._stepsContents.filter(content => content.classList.contains(ClassName.ACTIVE))
 
   if (showEvent.defaultPrevented) {
     return
   }
 
   if (activeStep.length) {
-    activeStep[0].classList.remove(options.classNames.active)
+    activeStep[0].classList.remove(ClassName.ACTIVE)
   }
   if (activeContent.length) {
-    activeContent[0].classList.remove(options.classNames.active)
-    activeContent[0].classList.remove(options.classNames.block)
+    activeContent[0].classList.remove(ClassName.ACTIVE)
+    activeContent[0].classList.remove(ClassName.BLOCK)
   }
 
   showStep(stepperNode, stepper._steps[indexStep], stepper._steps, options)
@@ -45,17 +53,17 @@ const showStep = (stepperNode, step, stepList, options) => {
 
     trigger.setAttribute('aria-selected', 'false')
     // if stepper is in linear mode, set disabled attribute on the trigger
-    if (stepperNode.classList.contains(options.classNames.linear)) {
+    if (stepperNode.classList.contains(ClassName.LINEAR)) {
       trigger.setAttribute('disabled', 'disabled')
     }
   })
 
-  step.classList.add(options.classNames.active)
+  step.classList.add(ClassName.ACTIVE)
   const currentTrigger = step.querySelector(options.selectors.trigger)
 
   currentTrigger.setAttribute('aria-selected', 'true')
   // if stepper is in linear mode, remove disabled attribute on current
-  if (stepperNode.classList.contains(options.classNames.linear)) {
+  if (stepperNode.classList.contains(ClassName.LINEAR)) {
     currentTrigger.removeAttribute('disabled')
   }
 }
@@ -69,24 +77,24 @@ const showContent = (stepperNode, content, contentList, activeContent, options) 
   })
 
   function complete () {
-    content.classList.add(options.classNames.block)
+    content.classList.add(ClassName.BLOCK)
     content.removeEventListener(transitionEndEvent, complete)
     stepperNode.dispatchEvent(shownEvent)
   }
 
-  if (content.classList.contains(options.classNames.fade)) {
-    content.classList.remove(options.classNames.none)
+  if (content.classList.contains(ClassName.FADE)) {
+    content.classList.remove(ClassName.NONE)
     const duration = getTransitionDurationFromElement(content)
 
     content.addEventListener(transitionEndEvent, complete)
     if (activeContent.length) {
-      activeContent[0].classList.add(options.classNames.none)
+      activeContent[0].classList.add(ClassName.NONE)
     }
 
-    content.classList.add(options.classNames.active)
+    content.classList.add(ClassName.ACTIVE)
     emulateTransitionEnd(content, duration)
   } else {
-    content.classList.add(options.classNames.active)
+    content.classList.add(ClassName.ACTIVE)
     stepperNode.dispatchEvent(shownEvent)
   }
 }
@@ -133,14 +141,15 @@ const emulateTransitionEnd = (element, duration) => {
 const detectAnimation = (contentList, options) => {
   if (options.animation) {
     contentList.forEach(content => {
-      content.classList.add(options.classNames.fade)
-      content.classList.add(options.classNames.none)
+      content.classList.add(ClassName.FADE)
+      content.classList.add(ClassName.NONE)
     })
   }
 }
 
 export {
   show,
+  ClassName,
   customProperty,
   detectAnimation
 }

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -1,27 +1,14 @@
 import { WinEvent, createCustomEvent } from './polyfill'
 
 const MILLISECONDS_MULTIPLIER = 1000
-const Selectors = {
-  STEPS: '.step',
-  TRIGGER: '.step-trigger',
-  STEPPER: '.bs-stepper'
-}
-
-const ClassName = {
-  ACTIVE: 'active',
-  LINEAR: 'linear',
-  BLOCK: 'dstepper-block',
-  NONE: 'dstepper-none',
-  FADE: 'fade'
-}
 
 const transitionEndEvent = 'transitionend'
 const customProperty = 'bsStepper'
 
-const show = (stepperNode, indexStep) => {
+const show = (stepperNode, indexStep, options) => {
   const stepper = stepperNode[customProperty]
 
-  if (stepper._steps[indexStep].classList.contains(ClassName.ACTIVE) || stepper._stepsContents[indexStep].classList.contains(ClassName.ACTIVE)) {
+  if (stepper._steps[indexStep].classList.contains(options.classNames.active) || stepper._stepsContents[indexStep].classList.contains(options.classNames.active)) {
     return
   }
 
@@ -33,47 +20,47 @@ const show = (stepperNode, indexStep) => {
   })
   stepperNode.dispatchEvent(showEvent)
 
-  const activeStep = stepper._steps.filter(step => step.classList.contains(ClassName.ACTIVE))
-  const activeContent = stepper._stepsContents.filter(content => content.classList.contains(ClassName.ACTIVE))
+  const activeStep = stepper._steps.filter(step => step.classList.contains(options.classNames.active))
+  const activeContent = stepper._stepsContents.filter(content => content.classList.contains(options.classNames.active))
 
   if (showEvent.defaultPrevented) {
     return
   }
 
   if (activeStep.length) {
-    activeStep[0].classList.remove(ClassName.ACTIVE)
+    activeStep[0].classList.remove(options.classNames.active)
   }
   if (activeContent.length) {
-    activeContent[0].classList.remove(ClassName.ACTIVE)
-    activeContent[0].classList.remove(ClassName.BLOCK)
+    activeContent[0].classList.remove(options.classNames.active)
+    activeContent[0].classList.remove(options.classNames.block)
   }
 
-  showStep(stepperNode, stepper._steps[indexStep], stepper._steps)
-  showContent(stepperNode, stepper._stepsContents[indexStep], stepper._stepsContents, activeContent)
+  showStep(stepperNode, stepper._steps[indexStep], stepper._steps, options)
+  showContent(stepperNode, stepper._stepsContents[indexStep], stepper._stepsContents, activeContent, options)
 }
 
-const showStep = (stepperNode, step, stepList) => {
+const showStep = (stepperNode, step, stepList, options) => {
   stepList.forEach(step => {
-    const trigger = step.querySelector(Selectors.TRIGGER)
+    const trigger = step.querySelector(options.selectors.trigger)
 
     trigger.setAttribute('aria-selected', 'false')
     // if stepper is in linear mode, set disabled attribute on the trigger
-    if (stepperNode.classList.contains(ClassName.LINEAR)) {
+    if (stepperNode.classList.contains(options.classNames.linear)) {
       trigger.setAttribute('disabled', 'disabled')
     }
   })
 
-  step.classList.add(ClassName.ACTIVE)
-  const currentTrigger = step.querySelector(Selectors.TRIGGER)
+  step.classList.add(options.classNames.active)
+  const currentTrigger = step.querySelector(options.selectors.trigger)
 
   currentTrigger.setAttribute('aria-selected', 'true')
   // if stepper is in linear mode, remove disabled attribute on current
-  if (stepperNode.classList.contains(ClassName.LINEAR)) {
+  if (stepperNode.classList.contains(options.classNames.linear)) {
     currentTrigger.removeAttribute('disabled')
   }
 }
 
-const showContent = (stepperNode, content, contentList, activeContent) => {
+const showContent = (stepperNode, content, contentList, activeContent, options) => {
   const shownEvent = createCustomEvent('shown.bs-stepper', {
     cancelable: true,
     detail: {
@@ -82,24 +69,24 @@ const showContent = (stepperNode, content, contentList, activeContent) => {
   })
 
   function complete () {
-    content.classList.add(ClassName.BLOCK)
+    content.classList.add(options.classNames.block)
     content.removeEventListener(transitionEndEvent, complete)
     stepperNode.dispatchEvent(shownEvent)
   }
 
-  if (content.classList.contains(ClassName.FADE)) {
-    content.classList.remove(ClassName.NONE)
+  if (content.classList.contains(options.classNames.fade)) {
+    content.classList.remove(options.classNames.none)
     const duration = getTransitionDurationFromElement(content)
 
     content.addEventListener(transitionEndEvent, complete)
     if (activeContent.length) {
-      activeContent[0].classList.add(ClassName.NONE)
+      activeContent[0].classList.add(options.classNames.none)
     }
 
-    content.classList.add(ClassName.ACTIVE)
+    content.classList.add(options.classNames.active)
     emulateTransitionEnd(content, duration)
   } else {
-    content.classList.add(ClassName.ACTIVE)
+    content.classList.add(options.classNames.active)
     stepperNode.dispatchEvent(shownEvent)
   }
 }
@@ -143,19 +130,17 @@ const emulateTransitionEnd = (element, duration) => {
   }, emulatedDuration)
 }
 
-const detectAnimation = (contentList, animation) => {
-  if (animation) {
+const detectAnimation = (contentList, options) => {
+  if (options.animation) {
     contentList.forEach(content => {
-      content.classList.add(ClassName.FADE)
-      content.classList.add(ClassName.NONE)
+      content.classList.add(options.classNames.fade)
+      content.classList.add(options.classNames.none)
     })
   }
 }
 
 export {
   show,
-  Selectors,
-  ClassName,
   customProperty,
   detectAnimation
 }

--- a/tests/units/main.spec.js
+++ b/tests/units/main.spec.js
@@ -42,7 +42,19 @@ describe('Stepper', function () {
       expect(document.getElementById('trigger2').getAttribute('aria-selected')).toEqual('false')
       expect(stepper.options).toEqual({
         linear: true,
-        animation: false
+        animation: false,
+        selectors: {
+          steps: '.step',
+          trigger: '.step-trigger',
+          stepper: '.bs-stepper'
+        },
+        classNames: {
+          active: 'active',
+          linear: 'linear',
+          block: 'dstepper-block',
+          none: 'dstepper-none',
+          fade: 'fade'
+        }
       })
     })
 
@@ -82,7 +94,19 @@ describe('Stepper', function () {
       expect(stepperNode['bsStepper']).toEqual(stepper)
       expect(stepper.options).toEqual({
         linear: false,
-        animation: false
+        animation: false,
+        selectors: {
+          steps: '.step',
+          trigger: '.step-trigger',
+          stepper: '.bs-stepper'
+        },
+        classNames: {
+          active: 'active',
+          linear: 'linear',
+          block: 'dstepper-block',
+          none: 'dstepper-none',
+          fade: 'fade'
+        }
       })
     })
 
@@ -167,7 +191,19 @@ describe('Stepper', function () {
       setTimeout(function () {
         expect(stepper.options).toEqual({
           linear: true,
-          animation: true
+          animation: true,
+          selectors: {
+            steps: '.step',
+            trigger: '.step-trigger',
+            stepper: '.bs-stepper'
+          },
+          classNames: {
+            active: 'active',
+            linear: 'linear',
+            block: 'dstepper-block',
+            none: 'dstepper-none',
+            fade: 'fade'
+          }
         })
         expect(document.querySelector('#test1').classList.contains('fade')).toBe(true)
         expect(document.querySelector('#test2').classList.contains('fade')).toBe(true)

--- a/tests/units/main.spec.js
+++ b/tests/units/main.spec.js
@@ -219,6 +219,40 @@ describe('Stepper', function () {
       expect(trigger2.addEventListener).toHaveBeenCalled()
       expect(stepperNode['bsStepper']).toEqual(stepper)
     })
+
+    it('should allow CSS selector configuration', function () {
+      fixture.innerHTML = [
+        '<div id="myStepper" class="custom-bs-stepper">',
+        '  <div class="custom-step" data-target="#test1">',
+        '    <button id="trigger1" class="custom-step-trigger">1</button>',
+        '  </div>',
+        '  <div class="custom-step" data-target="#test2">',
+        '    <button id="trigger2" class="custom-step-trigger">2</button>',
+        '  </div>',
+        '  <div id="test1">1</div>',
+        '  <div id="test2">2</div>',
+        '</div>'
+      ].join('')
+
+      var stepperNode = document.getElementById('myStepper')
+      var stepper = new Stepper(stepperNode, {
+        selectors: {
+          steps: '.custom-step',
+          trigger: '.custom-step-trigger',
+          stepper: '.custom-bs-stepper'
+        }
+      })
+
+      expect(stepper.options).toEqual({
+        linear: true,
+        animation: false,
+        selectors: {
+          steps: '.custom-step',
+          trigger: '.custom-step-trigger',
+          stepper: '.custom-bs-stepper'
+        }
+      })
+    })
   })
 
   describe('next', function () {

--- a/tests/units/main.spec.js
+++ b/tests/units/main.spec.js
@@ -47,13 +47,6 @@ describe('Stepper', function () {
           steps: '.step',
           trigger: '.step-trigger',
           stepper: '.bs-stepper'
-        },
-        classNames: {
-          active: 'active',
-          linear: 'linear',
-          block: 'dstepper-block',
-          none: 'dstepper-none',
-          fade: 'fade'
         }
       })
     })
@@ -101,13 +94,6 @@ describe('Stepper', function () {
           steps: '.step',
           trigger: '.step-trigger',
           stepper: '.bs-stepper'
-        },
-        classNames: {
-          active: 'active',
-          linear: 'linear',
-          block: 'dstepper-block',
-          none: 'dstepper-none',
-          fade: 'fade'
         }
       })
     })
@@ -198,13 +184,6 @@ describe('Stepper', function () {
             steps: '.step',
             trigger: '.step-trigger',
             stepper: '.bs-stepper'
-          },
-          classNames: {
-            active: 'active',
-            linear: 'linear',
-            block: 'dstepper-block',
-            none: 'dstepper-none',
-            fade: 'fade'
           }
         })
         expect(document.querySelector('#test1').classList.contains('fade')).toBe(true)

--- a/tests/units/main.spec.js
+++ b/tests/units/main.spec.js
@@ -92,6 +92,8 @@ describe('Stepper', function () {
       expect(stepper._steps.length).toEqual(2)
       expect(document.querySelector('.step').classList.contains('active')).toBe(true)
       expect(stepperNode['bsStepper']).toEqual(stepper)
+      expect(stepper._clickStepLinearListener).toBeUndefined()
+      expect(stepper._clickStepNonLinearListener).toBeTruthy()
       expect(stepper.options).toEqual({
         linear: false,
         animation: false,
@@ -518,6 +520,8 @@ describe('Stepper', function () {
       expect(stepper._currentIndex).toEqual(0)
       expect(stepper._steps.length).toEqual(2)
       expect(stepper._stepsContents.length).toEqual(2)
+      expect(stepper._clickStepLinearListener).toBeTruthy()
+      expect(stepper._clickStepNonLinearListener).toBeUndefined()
 
       stepper.destroy()
 
@@ -526,6 +530,8 @@ describe('Stepper', function () {
       expect(stepper._currentIndex).toBeUndefined()
       expect(stepper._steps).toBeUndefined()
       expect(stepper._stepsContents).toBeUndefined()
+      expect(stepper._clickStepLinearListener).toBeUndefined()
+      expect(stepper._clickStepNonLinearListener).toBeUndefined()
     })
 
     it('should remove event listeners on triggers', function () {


### PR DESCRIPTION
I had an use case where I needed to separated controls and tabs while keeping the default style (turns out having multiple `.bs-stepper` breaks the plugin hooray).

Allowing the CSS selectors to be configured solved my use case and I thought maybe it would be useful for someone else. Tests passed and here I am.