### PR TITLE
(chore): remove superfluous argument passed to `buildClickStepLinearL…

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -59,7 +59,7 @@ class Stepper {
       const trigger = step.querySelector(this.options.selectors.trigger)
 
       if (this.options.linear) {
-        this._clickStepLinearListener = buildClickStepLinearListener(this.options)
+        this._clickStepLinearListener = buildClickStepLinearListener()
         trigger.addEventListener('click', this._clickStepLinearListener)
       } else {
         this._clickStepNonLinearListener = buildClickStepNonLinearListener(this.options)


### PR DESCRIPTION
…istener()`

Found with LGTM https://lgtm.com/projects/g/Johann-S/bs-stepper/alerts?mode=list

@Johann-S you should enable PR reviews with LGTM, just disable commenting