### PR TITLE
add class 'completed' to any step that comes before the 'active' step

### DIFF
--- a/src/js/util.js
+++ b/src/js/util.js
@@ -8,7 +8,8 @@ const ClassName = {
   BLOCK: 'dstepper-block',
   NONE: 'dstepper-none',
   FADE: 'fade',
-  VERTICAL: 'vertical'
+  VERTICAL: 'vertical',
+  COMPLETED: 'completed'
 }
 
 const transitionEndEvent = 'transitionend'
@@ -62,6 +63,7 @@ const showStep = (stepperNode, step, stepList, options) => {
     if (stepperNode.classList.contains(ClassName.LINEAR)) {
       trigger.setAttribute('disabled', 'disabled')
     }
+    step.classList.remove(ClassName.COMPLETED);
   })
 
   step.classList.add(ClassName.ACTIVE)
@@ -72,6 +74,12 @@ const showStep = (stepperNode, step, stepList, options) => {
   if (stepperNode.classList.contains(ClassName.LINEAR)) {
     currentTrigger.removeAttribute('disabled')
   }
+  const stepIndex = stepList.indexOf(step); 
+  stepList.forEach((itm, itmIndex) => {
+    if(itmIndex < stepIndex){
+      itm.classList.add(ClassName.COMPLETED); 
+    }
+  })
 }
 
 const showContent = (stepperNode, content, contentList, activeContent, done) => {


### PR DESCRIPTION
Adds a completed class to any step before the 'active' step.
![image](https://user-images.githubusercontent.com/37119470/122904910-ad16f100-d348-11eb-9dab-875b4d80744a.png)

This allows for styling the previous steps and adjacent connecting lines as described in issue #87
```css
.completed { background-color: green; }
.completed + .bs-stepper-line, .completed + .line { background-color: green; }
```
