### PR TITLE
Update README.md to add css import

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Or with npm
 
 ```js
 import Stepper from 'bs-stepper'
+import 'bs-stepper/dist/css/bs-stepper.min.css'
 ```
 
 ### Create a stepper


### PR DESCRIPTION
A while ago, I was stuck using bs-stepper in my React project, unable to move forward thinking that bs-stepper is not working. 
Later on I realized that I was missing a css import. So I thought of updating the README.md file for other people to save their time.

